### PR TITLE
Fix typo in /fixme endpoint to correctly destructure request body.\n\nThis resolves a TypeError caused by attempting to destructure properties from an undefined object (req.bod instead of req.body). The fix ensures that the request body is correctly accessed, allowing the /fixme endpoint to function as intended.

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ app.post('/users', (req, res) => {
 });
 
 app.post('/fixme', (req, res) => {
-  const { name } = req.bod;
+  const { name } = req.body;
   console.log(`WORKING: POST /fixme ${name}`);
   return res.send(`POST /fixme ${name}`);
 });


### PR DESCRIPTION
🤖 Generated by Insights AI
Co-Authored-By: insights-ai <noreply@insights.ai>
