### PR TITLE
Fix: Handle missing name in req.body and typo in /fixme route\n\nThis commit fixes a TypeError that occurs when the  property is missing from  in the  route. It also corrects a typo in the  route where  was used instead of .\n\n🤖 Generated by Insights AI\n\nCo-Authored-By: insights-ai <noreply@insights.ai>

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,13 +26,16 @@ app.get('/', (req, res) => {
 });
 
 app.post('/users', (req, res) => {
-  const { name } = req.body;
+  const name = req.body ? req.body.name : null;
+  if (!name) {
+    return res.status(400).send({ error: 'Name is required' });
+  }
   console.log(`WORKING: POST /users ${name}`);
   return res.send(`POST /users ${name}`);
 });
 
 app.post('/fixme', (req, res) => {
-  const { name } = req.bod;
+  const { name } = req.body;
   console.log(`WORKING: POST /fixme ${name}`);
   return res.send(`POST /fixme ${name}`);
 });


### PR DESCRIPTION
Generated by automated fix for log ID: 39084404259535546235057995985094635590848842395290763264