### PR TITLE
TypeError: Cannot destructure property '

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ app.post('/users', (req, res) => {
 });
 
 app.post('/fixme', (req, res) => {
-  const { name } = req.bod;
+  const { name } = req.body;
   console.log(`WORKING: POST /fixme ${name}`);
   return res.send(`POST /fixme ${name}`);
 });


### PR DESCRIPTION
Attempted to fix: TypeError: Cannot destructure property 'name' of 'req.bod' as it is undefined.

Generated by automated fix for log ID: 39124847695997568419529175319791561355258018718526668800