### PR TITLE
TypeError: Cannot destructure property '

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ app.get('/', (req, res) => {
 });
 
 app.post('/users', (req, res) => {
-  const { name } = req.body;
+  const name = req.body ? req.body.name : undefined;
   console.log(`WORKING: POST /users ${name}`);
   return res.send(`POST /users ${name}`);
 });


### PR DESCRIPTION
Attempted to fix: TypeError: Cannot destructure property 'name' of 'req.bod' as it is undefined.

Generated by automated fix for log ID: 39136132206754075320453118194629074847750742721927708672